### PR TITLE
feat: provide nuxt 2.9 compatible types

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -213,6 +213,13 @@ declare module '@nuxt/vue-app' {
   }
 }
 
+// Nuxt 2.9+
+declare module '@nuxt/types' {
+  interface Context {
+    readonly $dateFns: DateFns
+  }
+}
+
 declare module 'vue/types/vue' {
   interface Vue {
     readonly $dateFns: DateFns


### PR DESCRIPTION
Since Nuxt 2.9, types are defined around @nuxt/types packages.
These changes make the module types work with Nuxt 2.9 new TypeScript specs.