### PR TITLE
fix: add 'formatDuration' to fix #37

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -55,6 +55,7 @@ export default (ctx, inject) => {
     'endOfWeek',
     'formatDistanceToNow',
     'formatDistanceToNowStrict',
+    'formatDuration',
     'getWeek',
     'getWeekOfMonth',
     'getWeeksInMonth',


### PR DESCRIPTION
Added the 'formatDuration' method to the twoParams array to enable proper localization.