### PR TITLE
feat: add fallback locale

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,13 @@ Locales to be imported.
 
 You can preset default locale.
 
+### `fallbackLocale`
+
+- Type: `String`
+- Default: `null`
+
+You can preset a fallback locale for when a method is called with an unsupported locale.
+
 ### `format`
 
 - Type: `String`

--- a/lib/module.js
+++ b/lib/module.js
@@ -8,6 +8,7 @@ module.exports = function (moduleOptions) {
   const options = {
     locales: [],
     defaultLocale: null,
+    fallbackLocale: null,
     format: null,
     methods: null,
     ...this.options['date-fns'],
@@ -19,6 +20,10 @@ module.exports = function (moduleOptions) {
     options.defaultLocale = options.defaultLocale.replace(/[_-]/, '')
   }
 
+  if (options.fallbackLocale) {
+    options.fallbackLocale = options.fallbackLocale.replace(/[_-]/, '')
+  }
+
   if (!Array.isArray(options.locales)) {
     options.locales = [options.locales]
   }
@@ -27,6 +32,10 @@ module.exports = function (moduleOptions) {
 
   if (options.defaultLocale && !options.locales.includes(options.defaultLocale)) {
     options.locales.push(options.defaultLocale)
+  }
+
+  if (options.fallbackLocale && !options.locales.includes(options.fallbackLocale)) {
+    options.locales.push(options.fallbackLocale)
   }
 
   this.addPlugin({

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -85,10 +85,18 @@ function mergeOptions(options) {
   options = { locale: '<%= options.defaultLocale %>', ...options }
   <% } %>
 
+  <% if (options.fallbackLocale) { %>
+  options = { fallbackLocale: '<%= options.fallbackLocale %>', ...options }
+  <% } %>
+
   if (options && typeof options.locale === 'string') {
     const locale = options.locale.replace(/[_-]/, '')
+    const fallbackLocale = options.fallbackLocale ? options.fallbackLocale.replace(/[_-]/, '') : null
     if (locales[locale]) {
       options.locale = locales[locale]
+    } else if (fallbackLocale && locales[fallbackLocale]) {
+      console.warn(`[date-fns] locale '${options.locale}' not found, using fallback locale '${options.fallbackLocale}'`)
+      options.locale = locales[fallbackLocale]
     } else {
       console.warn(`[date-fns] locale '${options.locale}' not found.`)
     }

--- a/test/fallback-locale.test.js
+++ b/test/fallback-locale.test.js
@@ -1,0 +1,33 @@
+const { setup, loadConfig, get, url } = require('@nuxtjs/module-test-utils')
+
+describe('fallback locale', () => {
+  let nuxt
+
+  beforeAll(async () => {
+    ({ nuxt } = (await setup(loadConfig(__dirname, 'fallback-locale'))))
+  }, 60000)
+
+  afterAll(async () => {
+    await nuxt.close()
+  })
+
+  test('dateFns should be defined', async () => {
+    const window = await nuxt.renderAndGetWindow(url('/'))
+    expect(window.$nuxt.$dateFns).toBeDefined()
+  })
+
+  test('render monday with es fallback locale', async () => {
+    const html = await get('/')
+    expect(html).toContain('lunes')
+  })
+
+  test('render month', async () => {
+    const window = await nuxt.renderAndGetWindow(url('/'))
+    expect(window.document.querySelector('p').textContent).toBe('December')
+  })
+
+  test('render year', async () => {
+    const html = await get('/')
+    expect(html).toContain('1995')
+  })
+})

--- a/test/fixture/fallback-locale/nuxt.config.js
+++ b/test/fixture/fallback-locale/nuxt.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  rootDir: __dirname,
+  buildModules: [
+    { handler: require('../../../') }
+  ],
+  dateFns: {
+    locales: 'unsupportedLocale',
+    fallbackLocale: 'es'
+  }
+}

--- a/test/fixture/fallback-locale/pages/index.vue
+++ b/test/fixture/fallback-locale/pages/index.vue
@@ -1,0 +1,17 @@
+<template>
+  <div>
+    {{ $dateFns.format('1995-12-25', 'EEEE', { locale: 'unsupportedLocale' }) }}
+    <p v-text="str" />
+    {{ $dateFns.format('1995-12-25', 'yyyy') }}
+  </div>
+</template>
+
+<script>
+export default {
+  asyncData (ctx) {
+    return {
+      str: ctx.app.$dateFns.format('1995-12-25', 'MMMM')
+    }
+  }
+}
+</script>


### PR DESCRIPTION
I've added a `fallbackLocale` setting which allows the functions to use it if we give them an unsupported locale.

This is useful cause in the case where we support a lot of i18n locales, we tend to pass the current one to the date-fns functions. But having a unsupported locale passed to date-fns would crash it. 

With this, it'll instead first check the presence of the `fallbackLocale` and use it if it exists.